### PR TITLE
[#8] Add operator to call command without displaying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `shellmet` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.0.2.0 — Jul 4, 2019
+
+* [#8](https://github.com/kowainik/shellmet/issues/8):
+  Implement `$^` operator that doesn't print the command to terminal.
+
 ## 0.0.1 — Apr 9, 2019
 
 * Generalise the type of the `$?` operator to allow returning values on

--- a/shellmet.cabal
+++ b/shellmet.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                shellmet
-version:             0.0.1
+version:             0.0.2.0
 synopsis:            Out of the shell solution for scripting in Haskell
 description:         Shellmet provides easy and convenient way to call shell commands from Haskell programs
 homepage:            https://github.com/kowainik/shellmet

--- a/src/Shellmet.hs
+++ b/src/Shellmet.hs
@@ -13,6 +13,7 @@ Hello World!
 
 module Shellmet
        ( ($|)
+       , ($^)
        , ($?)
        ) where
 
@@ -45,6 +46,7 @@ instance (a ~ [Text], b ~ IO ()) => IsString (a -> b) where
         let cmdStr = showCommandForUser cmd (map T.unpack args)
         putStrLn $ "⚙  " ++ cmdStr
         callCommand cmdStr
+    {-# INLINE fromString #-}
 
 {- | Run shell command with given options and return stripped stdout of the
 executed command.
@@ -55,6 +57,18 @@ executed command.
 infix 5 $|
 ($|) :: FilePath -> [Text] -> IO Text
 cmd $| args = T.strip . T.pack <$> readProcess cmd (map T.unpack args) ""
+{-# INLINE ($|) #-}
+
+{- | This operator runs shell command with given options but doesn't print the
+command itself.
+
+>>> "echo" $^ ["Foo", "Bar"]
+Foo Bar
+-}
+infix 5 $^
+($^) :: FilePath -> [Text] -> IO ()
+cmd $^ args = callCommand $ showCommandForUser cmd (map T.unpack args)
+{-# INLINE ($^) #-}
 
 {- | Do some IO actions when process failed with 'IOError'.
 
@@ -68,3 +82,4 @@ Command failed
 infixl 4 $?
 ($?) :: IO a -> IO a -> IO a
 action $? handler = action `catch` \(_ :: IOError) -> handler
+{-# INLINE ($?) #-}


### PR DESCRIPTION
Resolves #8

I cannot think of better name so it's called `$^`.