### PR TITLE
[#13] Build with GHC-8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: haskell
 git:
   depth: 5
 
-cabal: "2.4"
+cabal: "3.0"
 
 cache:
   directories:
@@ -14,9 +14,9 @@ cache:
 
 matrix:
   include:
-  - ghc: 8.2.2
   - ghc: 8.4.4
   - ghc: 8.6.5
+  - ghc: 8.8.1
 
   - ghc: 8.6.5
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
@@ -24,8 +24,8 @@ matrix:
 install:
   - |
     if [ -z "$STACK_YAML" ]; then
-      cabal new-update
-      cabal new-build --enable-tests --enable-benchmarks
+      cabal update
+      cabal build --enable-tests --enable-benchmarks
     else
       curl -sSL https://get.haskellstack.org/ | sh
       stack --version
@@ -37,7 +37,7 @@ script:
   - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .
   - |
     if [ -z "$STACK_YAML" ]; then
-       cabal new-test
+       cabal test
     else
       stack build --system-ghc --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 `shellmet` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-## Unreleased
+## Unreleased: 0.0.3.0
 
 * [#10](https://github.com/kowainik/shellmet/issues/10):
   Add doctest.
+  (by [@vrom911](https://github.com/vrom911))
+* [#13](https://github.com/kowainik/shellmet/issues/13):
+  Support GHC-8.8.1. Drop support for GHC-8.2.2.
+  (by [@chshersh](https://github.com/chshersh))
 
 ## 0.0.2.0 — Jul 4, 2019
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build status](https://img.shields.io/travis/kowainik/shellmet.svg?logo=travis)](https://travis-ci.org/kowainik/shellmet)
 [![Hackage](https://img.shields.io/hackage/v/shellmet.svg?logo=haskell)](https://hackage.haskell.org/package/shellmet)
-[![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](LICENSE)
 [![Stackage Lts](http://stackage.org/package/shellmet/badge/lts)](http://stackage.org/lts/package/shellmet)
 [![Stackage Nightly](http://stackage.org/package/shellmet/badge/nightly)](http://stackage.org/nightly/package/shellmet)
+[![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](LICENSE)
 
 Out of the shell solution for scripting in Haskell. Shellmet provides an easy and
 convenient way to call shell commands from Haskell programs.
@@ -15,7 +15,7 @@ This README contains the usage example of the `shellmet` library. The example is
 runnable. You can build and execute with the following command:
 
 ```shell
-cabal new-run readme
+cabal run readme
 ```
 
 ### Setting up
@@ -26,7 +26,6 @@ necessary pragmas and imports.
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
 
-import Data.Semigroup ((<>))
 import Shellmet (($|))
 
 import qualified Data.Text as T

--- a/shellmet.cabal
+++ b/shellmet.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                shellmet
-version:             0.0.2.0
+version:             0.0.3.0
 synopsis:            Out of the shell solution for scripting in Haskell
 description:         Shellmet provides easy and convenient way to call shell commands from Haskell programs
 homepage:            https://github.com/kowainik/shellmet
@@ -14,16 +14,16 @@ category:            Shell, Command Line
 build-type:          Simple
 extra-doc-files:     README.md
                    , CHANGELOG.md
-tested-with:         GHC == 8.2.2
-                     GHC == 8.4.4
+tested-with:         GHC == 8.4.4
                      GHC == 8.6.5
+                     GHC == 8.8.1
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/shellmet.git
 
 common common-options
-  build-depends:       base >= 4.10.1.0 && < 4.13
+  build-depends:       base >= 4.11 && < 4.14
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-13.21
+resolver: lts-14.3

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -1,12 +1,9 @@
-{-# LANGUAGE CPP #-}
-
 module Main (main) where
 
 import System.FilePath.Glob (glob)
 import Test.DocTest (doctest)
 
 main :: IO ()
-#if ( __GLASGOW_HASKELL__ >= 804 )
 main = do
     sourceFiles <- glob "src/**/*.hs"
     doctest
@@ -14,6 +11,3 @@ main = do
         : "-XOverloadedStrings"
         : "-XScopedTypeVariables"
         : sourceFiles
-#else
-main = pure ()
-#endif


### PR DESCRIPTION
Resolves #13

**Note:** Travis CI should specify `cabal-install` version `3.0` because GHC-8.8 doesn't work on older Cabal versions (I don't know why, but I don't see any downsides now).

What we can clean up when dropping support for GHC-8.2.2:

* Remove `Data.Semigroup` imports from our code!