### PR TITLE
Prepare for the 0.0.3.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ cabal.project.local
 .HTF/
 # Stack
 .stack-work/
+stack.yaml.lock
 
 ### IDE/support
 # Vim

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,23 @@ cache:
 
 matrix:
   include:
+  - ghc: 8.2.2
   - ghc: 8.4.4
   - ghc: 8.6.5
   - ghc: 8.8.1
 
-  - ghc: 8.6.5
+  - ghc: 8.8.1
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:
   - |
     if [ -z "$STACK_YAML" ]; then
       cabal update
-      cabal build --enable-tests --enable-benchmarks
+      cabal build --enable-tests --enable-benchmarks --write-ghc-environment-files=always
     else
       curl -sSL https://get.haskellstack.org/ | sh
       stack --version
-      stack build --system-ghc --test --no-run-tests
+      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --no-terminal
     fi
 
 script:
@@ -37,9 +38,9 @@ script:
   - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .
   - |
     if [ -z "$STACK_YAML" ]; then
-       cabal test
+       cabal test --enable-tests
     else
-      stack build --system-ghc --test --bench --no-run-benchmarks --no-terminal --ghc-options=-Werror
+      stack test --system-ghc
     fi
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 `shellmet` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-## Unreleased: 0.0.3.0
+## 0.0.3.0 — Sep 28, 2019
 
 * [#10](https://github.com/kowainik/shellmet/issues/10):
   Add doctest.
   (by [@vrom911](https://github.com/vrom911))
 * [#13](https://github.com/kowainik/shellmet/issues/13):
-  Support GHC-8.8.1. Drop support for GHC-8.2.2.
+  Support GHC-8.8.1.
   (by [@chshersh](https://github.com/chshersh))
 
 ## 0.0.2.0 — Jul 4, 2019

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ necessary pragmas and imports.
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
 
+import Data.Semigroup ((<>))
 import Shellmet (($|))
 
 import qualified Data.Text as T

--- a/shellmet.cabal
+++ b/shellmet.cabal
@@ -13,8 +13,9 @@ copyright:           2019 Kowainik
 category:            Shell, Command Line
 build-type:          Simple
 extra-doc-files:     README.md
-                   , CHANGELOG.md
-tested-with:         GHC == 8.4.4
+                     CHANGELOG.md
+tested-with:         GHC == 8.2.2
+                     GHC == 8.4.4
                      GHC == 8.6.5
                      GHC == 8.8.1
 
@@ -23,7 +24,7 @@ source-repository head
   location:            https://github.com/kowainik/shellmet.git
 
 common common-options
-  build-depends:       base >= 4.11 && < 4.14
+  build-depends:       base >= 4.10.1.0 && < 4.14
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-14.3
+resolver: nightly-2019-09-28


### PR DESCRIPTION
I decided to return GHC-8.2.2 support back since it doesn't cost much.