### PR TITLE
avoid callCommand . showCommandForUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ necessary pragmas and imports.
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
 
-import Data.Semigroup ((<>))
 import Shellmet (($|))
 
 import qualified Data.Text as T

--- a/src/Shellmet.hs
+++ b/src/Shellmet.hs
@@ -29,7 +29,7 @@ module Shellmet
 import Control.Exception (catch)
 import Data.String (IsString (..))
 import Data.Text (Text)
-import System.Process (callCommand, readProcess, showCommandForUser)
+import System.Process (callProcess, readProcess, showCommandForUser)
 
 import qualified Data.Text as T
 
@@ -44,9 +44,9 @@ Doctest.hs
 instance (a ~ [Text], b ~ IO ()) => IsString (a -> b) where
     fromString :: String -> [Text] -> IO ()
     fromString cmd args = do
-        let cmdStr = showCommandForUser cmd (map T.unpack args)
-        putStrLn $ "⚙  " ++ cmdStr
-        callCommand cmdStr
+        let argStrs = map T.unpack args
+        putStrLn $ "⚙  " ++ showCommandForUser cmd argStrs
+        callProcess cmd argStrs
     {-# INLINE fromString #-}
 
 {- | Run shell command with given options and return stripped stdout of the
@@ -68,7 +68,7 @@ Foo Bar
 -}
 infix 5 $^
 ($^) :: FilePath -> [Text] -> IO ()
-cmd $^ args = callCommand $ showCommandForUser cmd (map T.unpack args)
+cmd $^ args = callProcess cmd (map T.unpack args)
 {-# INLINE ($^) #-}
 
 {- | Do some IO actions when process failed with 'IOError'.


### PR DESCRIPTION
We found (https://github.com/unisonweb/unison/issues/1870) that even though the `System.Process.showCommandForUser` docs say:

> Given a program _p_ and arguments _args_, `showCommandForUser p args` returns a string suitable for pasting into /bin/sh (on Unix systems) or CMD.EXE (on Windows).

that while this string may have been suitable for pasting into `CMD.EXE` on Windows, it wasn't suitable for passing to `System.Process.callCommand` on Windows, which was causing failures.

This PR passes the command arguments directly to `callProcess` instead of collapsing them into single string and then trying to parse them apart again within `callCommand`.

The PR also removes a redundant import from `README.md`, which was causing our build to fail (we don't allow warnings).

Thanks for this library!